### PR TITLE
Remove notification after 5 sec

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -5,3 +5,7 @@
 //
 //
 
+//Auto hide for notification
+$(document).on('page:change', function(){
+     $(".alert").delay(5000).slideUp(500);
+    });

--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -7,5 +7,5 @@
 
 //Auto hide for notification
 $(document).on('page:change', function(){
-     $(".alert").delay(5000).slideUp(500);
+     $(".notice-container").delay(5000).slideUp(500);
     });

--- a/app/views/custom/layouts/_flash.html.erb
+++ b/app/views/custom/layouts/_flash.html.erb
@@ -1,0 +1,13 @@
+<% flash.each do |flash_key, flash_message| %>
+    <div id="<%= flash_key %>" data-alert class="notice-container callout-slide" data-closable>
+      <div class="callout notice <%= flash_key %>" role="alert">
+        <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <div class="notice-text">
+          <%= flash_message.try(:html_safe) %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |flash_key, flash_message| %>
   <div id="<%= flash_key %>" data-alert class="notice-container callout-slide" data-closable>
-    <div class="callout notice <%= flash_key %>" role="alert">
+    <div class="callout notice <%= flash_key %>">
       <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
         <span aria-hidden="true">&times;</span>
       </button>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |flash_key, flash_message| %>
   <div id="<%= flash_key %>" data-alert class="notice-container callout-slide" data-closable>
-    <div class="callout notice <%= flash_key %>">
+    <div class="callout notice <%= flash_key %>" role="alert">
       <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
         <span aria-hidden="true">&times;</span>
       </button>


### PR DESCRIPTION
## References

Related to issue https://zube.io/tbs-sct/gctools/c/3751

## Objectives

Make notification accessible with auto hide

## Visual Changes

After 5 sec, the notification will hide.

## Notes

I add role='alert' to the div so the screen reader will be notice.
