### PR TITLE
Remove close button from notice / move alert role to parent

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -7,5 +7,5 @@
 
 //Auto hide for notification
 $(document).on('page:change', function(){
-     $(".notice-container").delay(5000).slideUp(500);
+     $('[role="alert"]').delay(5000).slideUp(500);
     });

--- a/app/views/custom/layouts/_flash.html.erb
+++ b/app/views/custom/layouts/_flash.html.erb
@@ -1,9 +1,6 @@
 <% flash.each do |flash_key, flash_message| %>
-    <div id="<%= flash_key %>" data-alert class="notice-container callout-slide" data-closable>
-      <div class="callout notice <%= flash_key %>" role="alert">
-        <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
-          <span aria-hidden="true">&times;</span>
-        </button>
+    <div id="<%= flash_key %>" data-alert class="notice-container callout-slide" role="alert">
+      <div class="callout notice <%= flash_key %>" >
         <div class="notice-text">
           <%= flash_message.try(:html_safe) %>
         </div>


### PR DESCRIPTION
## Objectives

Remove the close button on the notice alert that was not functioning. Test with screen reader to ensure change operates smoothly

## Visual Changes

Remove 'X' from notice callout

## Notes

Tested with ChromeVox web screen reader.  Moved `role="alert"` to top callout div level to align with normal close behavior.
